### PR TITLE
Manually remove the minizip files

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,18 +57,7 @@
   </platform>
   <platform name="osx">
     <source-file src="src/ios/ContentSync.m"/>
-    <source-file src="src/ios/SSZipArchive.m" target-dir="minizip"/>
-    <source-file src="src/ios/minizip/zip.c" target-dir="minizip"/>
-    <source-file src="src/ios/minizip/unzip.c" target-dir="minizip"/>
-    <source-file src="src/ios/minizip/mztools.c" target-dir="minizip"/>
-    <source-file src="src/ios/minizip/ioapi.c" target-dir="minizip"/>
     <header-file src="src/ios/ContentSync.h"/>
-    <header-file src="src/ios/SSZipArchive.h" target-dir="minizip"/>
-    <header-file src="src/ios/minizip/zip.h" target-dir="minizip"/>
-    <header-file src="src/ios/minizip/unzip.h" target-dir="minizip"/>
-    <header-file src="src/ios/minizip/mztools.h" target-dir="minizip"/>
-    <header-file src="src/ios/minizip/ioapi.h" target-dir="minizip"/>
-    <header-file src="src/ios/minizip/crypt.h" target-dir="minizip"/>
     <config-file target="config.xml" parent="/*">
       <feature name="Sync">
         <param name="osx-package" value="ContentSync"/>


### PR DESCRIPTION
So that this plugin can be installed at the same time as other plugins that use
minizip.

TODO: Switch to a cocoapod instead so that this won't be an issue any more

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
